### PR TITLE
Responsive fixes

### DIFF
--- a/src/components/BaseCard.vue
+++ b/src/components/BaseCard.vue
@@ -24,12 +24,11 @@
         <div v-else class="px-3 px-xl-0 mx-auto">
           <div
             :class="{'is-right-skew': !isLeft, 'is-left-skew': isLeft}"
-            class="card-image-wrapper position-relative"
+            class="card-image-wrapper skew-effect position-relative"
           >
-            <picture class="card-image position-relative">
-              <source :srcset="image.xl.src" :media="`(min-width: ${gridBreakpoints.xl}px)`" />
+            <div class="card-image position-relative">
               <img :src="image.default.src" :alt="image.alt" />
-            </picture>
+            </div>
           </div>
         </div>
       </div>
@@ -60,6 +59,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 $card-border-top: 24px;
+$amount-of-card-image-inside-card-in-responsive: 80px;
 $shadow-small: $box-shadow-md, $box-shadow-sm;
 .wrapper-card {
   box-shadow: $shadow-small;
@@ -70,8 +70,31 @@ $shadow-small: $box-shadow-md, $box-shadow-sm;
 .card-image-wrapper {
   @include media-breakpoint-down(lg) {
     // the height of image inside card (in viewport < lg)
-    height: rem(80px);
+    height: rem($amount-of-card-image-inside-card-in-responsive);
   }
+}
+// for the space above card in mobile
+.ghost-card-image {
+  visibility: hidden;
+  img {
+    margin-top: rem(
+      -$amount-of-card-image-inside-card-in-responsive + -$card-border-top
+    );
+  }
+}
+
+.card-image {
+  img {
+    max-width: 100%;
+    border-radius: rem(10px);
+
+    @include media-breakpoint-down(lg) {
+      transform: translateY(-80%);
+      box-shadow: $shadow-small;
+    }
+  }
+}
+.skew-effect {
   @include media-breakpoint-up(xl) {
     transform: scale(1.15);
     &::before {
@@ -84,49 +107,44 @@ $shadow-small: $box-shadow-md, $box-shadow-sm;
       filter: blur(2px);
       box-shadow: 0 0 4.5rem rgba($black, 0.2);
     }
-    &.is-right-skew {
-      left: rem(96px);
-      &::before {
-        right: rem(4px);
-        left: 0;
-        transform: rotate(5.5deg) translateX(-16px) translateY(12px) skewX(2deg)
-          skewY(-4deg);
-      }
-    }
-    &.is-left-skew {
-      right: rem(96px);
-      &::before {
-        left: rem(4px);
-        right: 0;
-        transform: rotate(-5.5deg) translateX(16px) translateY(12px)
-          skewX(-2deg) skewY(4deg);
+    .card-image {
+      img {
+        .is-right-skew & {
+          transform: matrix(0.99, 0.04, -0.11, 1, 0, 0);
+        }
+        .is-left-skew & {
+          transform: matrix(0.99, -0.04, 0.11, 1, 0, 0);
+        }
       }
     }
   }
-}
-// for the space above card in mobile
-.ghost-card-image {
-  visibility: hidden;
-  img {
-    margin-top: rem(-80px + -$card-border-top);
-  }
-}
-.card-image {
-  img {
-    @include media-breakpoint-up(xl) {
-      .is-right-skew & {
+
+  &.is-right-skew {
+    left: rem(96px);
+    &::before {
+      right: rem(4px);
+      left: 0;
+      transform: rotate(5.5deg) translateX(-16px) translateY(12px) skewX(2deg)
+        skewY(-4deg);
+    }
+    .card-image {
+      img {
         transform: matrix(0.99, 0.04, -0.11, 1, 0, 0);
       }
-      .is-left-skew & {
+    }
+  }
+  &.is-left-skew {
+    right: rem(96px);
+    &::before {
+      left: rem(4px);
+      right: 0;
+      transform: rotate(-5.5deg) translateX(16px) translateY(12px) skewX(-2deg)
+        skewY(4deg);
+    }
+    .card-image {
+      img {
         transform: matrix(0.99, -0.04, 0.11, 1, 0, 0);
       }
-    }
-    max-width: 100%;
-    border-radius: rem(10px);
-
-    @include media-breakpoint-down(lg) {
-      transform: translateY(-80%);
-      box-shadow: $shadow-small;
     }
   }
 }

--- a/src/components/BaseCard.vue
+++ b/src/components/BaseCard.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="position-relative">
     <div class="ghost-wrapper px-3 d-xl-none">
-      <picture v-if="!showPlaceholder" class="ghost-card-image d-table mx-auto px-3">
-        <source :srcset="image.xl.src" :media="`(min-width: ${gridBreakpoints.xl})`" />
-        <img :src="image.default.src" :alt="image.alt" />
-      </picture>
+      <div v-if="!showPlaceholder" class="ghost-card-image d-table mx-auto px-3">
+        <picture>
+          <source :srcset="image.xl.src" :media="`(min-width: ${gridBreakpoints.xl})`" />
+          <img :src="image.default.src" :alt="image.alt" />
+        </picture>
+      </div>
     </div>
     <div :class="{'flex-row-reverse': isLeft}" class="wrapper-card row no-gutters mx-3 mx-xl-0">
       <div class="text col-12 col-xl-6 order-2 order-xl-1">
@@ -57,16 +59,18 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-$shadow-small: 0px 9px 24px rgba($black, 0.25), 0px 4px 4px rgba($black, 0.25);
+$card-border-top: 24px;
+$shadow-small: $box-shadow-md, $box-shadow-sm;
 .wrapper-card {
   box-shadow: $shadow-small;
   border-radius: rem(15px);
-  border-top: rem(24px) solid $primary;
+  border-top: rem($card-border-top) solid $primary;
   background: $brand-2;
 }
 .card-image-wrapper {
   @include media-breakpoint-down(lg) {
-    height: rem(64px);
+    // the height of image inside card (in viewport < lg)
+    height: rem(80px);
   }
   @include media-breakpoint-up(xl) {
     transform: scale(1.15);
@@ -104,8 +108,7 @@ $shadow-small: 0px 9px 24px rgba($black, 0.25), 0px 4px 4px rgba($black, 0.25);
 .ghost-card-image {
   visibility: hidden;
   img {
-    height: 82%;
-    margin-top: calc(-24px - 16px - 18%);
+    margin-top: rem(-80px + -$card-border-top);
   }
 }
 .card-image {
@@ -122,7 +125,7 @@ $shadow-small: 0px 9px 24px rgba($black, 0.25), 0px 4px 4px rgba($black, 0.25);
     border-radius: rem(10px);
 
     @include media-breakpoint-down(lg) {
-      transform: translateY(-82%);
+      transform: translateY(-80%);
       box-shadow: $shadow-small;
     }
   }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -17,9 +17,14 @@
 .text-decoration-underline {
   text-decoration: underline;
 }
-.is-huge {
+.font-size-huge {
   font-size: $huge-font-size;
   line-height: 1;
+}
+.font-size-xl-huge {
+  @include media-breakpoint-up(xl) {
+    font-size: $huge-font-size;
+  }
 }
 .is-huge-placeholder {
   // 24 + 8 is border-art height and margin
@@ -50,6 +55,11 @@ body,
 }
 .shift-down {
   margin-bottom: rem(-40px);
+}
+.shift-xl-down {
+  @include media-breakpoint-up(xl) {
+    margin-bottom: rem(-40px);
+  }
 }
 .aspect-ratio-box {
   height: 0;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,14 +17,14 @@
       ></video-player>
     </div>
 
-    <div class="pattern-area-1 pt-5 pt-xl-0 position-relative">
+    <div class="pattern-area-1 pt-0 position-relative">
 
       <div class="container is-small mb-4">
-        <base-heading :class-placeholder="'is-huge-placeholder'" :show-placeholder="!resort.id" :text="'Shinta Mani Wild'" :type="'h1'" :class-name="'h1 is-huge text-dark text-center'" :border-art="true" ></base-heading>
+        <base-heading :class-placeholder="'is-huge-placeholder'" :show-placeholder="!resort.id" :text="'Shinta Mani Wild'" :type="'h1'" :class-name="'h1 font-size-xl-huge text-dark text-center'" :border-art="true" ></base-heading>
       </div>
 
       <!-- quote -->
-      <section class="container shift-down">
+      <section class="container shift-xl-down home--quote-wrapper">
         <base-quote :show-placeholder="!resort.id" :class-name="'is-left'">
           <div class="quote w-100 h-100" v-html="resort.description"></div>
         </base-quote>
@@ -33,7 +33,7 @@
       <!-- card -->
       <div class="container is-small">
         <div class="row mb-5">
-          <div class="column-12">
+          <div class="col-12">
             <base-card :show-placeholder="!resort.id" :image="cardImage1">
               <template v-slot:text>
                 <div class="card-content">
@@ -53,15 +53,13 @@
       </div>
 
       <!-- banner action -->
-      <div class="mb-5">
-        <base-banner-action :image="resort.backgroundImage" :show-placeholder="!resort.id" :link="resort.ctaLink" :text="resort.ctaText">
-        </base-banner-action>
-      </div>
+      <base-banner-action :image="resort.backgroundImage" :show-placeholder="!resort.id" :link="resort.ctaLink" :text="resort.ctaText">
+      </base-banner-action>
 
-      <div class="pattern-area-2 position-relative">
+      <div class="pattern-area-2 position-relative pt-5">
 
       <!-- quote tents -->
-      <div class="position-relative">
+      <div class="position-relative shift-xl-down home--quote-wrapper">
         <section class="container">
           <base-quote :show-placeholder="!resort.id" :class-name="'is-right'">
             <div class="quote w-100 h-100" v-html="resort.h2"></div>
@@ -87,7 +85,7 @@
       <!-- card -->
       <div class="container is-small">
         <div class="row mb-5">
-          <div class="column-12">
+          <div class="col-12">
             <base-card :show-placeholder="!resort.id" :image="cardImage2" :is-left="true">
               <template v-slot:text>
                 <div class="card-content">
@@ -284,6 +282,11 @@ export default Vue.extend({
   b {
     font-weight: bold;
     display: block;
+  }
+}
+.home--quote-wrapper {
+  @include media-breakpoint-down(lg) {
+    margin-bottom: $spacer * 3;
   }
 }
 </style>

--- a/src/views/Listing.vue
+++ b/src/views/Listing.vue
@@ -41,7 +41,7 @@
       </div>
 
       <!-- quote -->
-      <section class="container shift-down">
+      <section class="container shift-xl-down mb-5 mb-xl-0">
         <base-quote :show-placeholder="!resort.id" :class-name="'is-right'">
           <div class="quote w-100 h-100" v-html="resort.h2"></div>
         </base-quote>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -58,7 +58,7 @@
       </div>
 
       <!-- quote -->
-      <section class="container shift-down">
+      <section class="container shift-xl-down mb-5 mb-xl-0">
         <base-quote :show-placeholder="!resort.id" :class-name="'is-left'">
           <div class="quote w-100 h-100" v-html="resort.h2"></div>
         </base-quote>


### PR DESCRIPTION
Responsive fixes for:  
- home contents (not header/footer)
- base-card component
- use shift-down (shift-xl-down) on xl screen only

#79 