### PR TITLE
fix smoother swipe transition

### DIFF
--- a/src/components/GallerySlider.vue
+++ b/src/components/GallerySlider.vue
@@ -347,17 +347,6 @@ export default Vue.extend({
   &:focus {
     background-color: $white;
   }
-  @include media-breakpoint-down(md) {
-    opacity: 0;
-    width: rem(104px);
-    top: 25%;
-    bottom: 25%;
-    height: auto;
-    border-radius: 0;
-    &:hover {
-      transform: translateX(0);
-    }
-  }
 }
 
 ::v-deep {

--- a/src/components/StorySlider.vue
+++ b/src/components/StorySlider.vue
@@ -75,8 +75,8 @@
       </div>
 
       <!-- Navigation -->
-      <div class="swiper-button-next swiper-button-white"></div>
-      <div class="swiper-button-prev swiper-button-white"></div>
+      <div class="swiper-button-next swiper-button-white d-none d-lg-block"></div>
+      <div class="swiper-button-prev swiper-button-white d-none d-lg-block"></div>
 
       <a
         class="story--back position-absolute p-2 p-md-3 cursor-pointer hover-button-bg"
@@ -442,17 +442,6 @@ export default Vue.extend({
   &:hover,
   &:focus {
     background-color: $white;
-  }
-  @include media-breakpoint-down(md) {
-    opacity: 0;
-    width: rem(104px);
-    top: 25%;
-    bottom: 25%;
-    height: auto;
-    border-radius: 0;
-    &:hover {
-      transform: translateX(0);
-    }
   }
 }
 


### PR DESCRIPTION
I was making left and right navigation buttons invisible in mobile but they were usable, swipe over those buttons is impossible so for having a good swipe experience we have to remove those buttons in mobile view.

#255 